### PR TITLE
Generated code from OpenAI

### DIFF
--- a/running-kubernetes-based-jenkins-servers.md
+++ b/running-kubernetes-based-jenkins-servers.md
@@ -1,0 +1,28 @@
+running-kubernetes-based-jenkins-servers.md
+
+Jenkins is a popular open-source automation server used for continuous integration and continuous delivery (CI/CD) pipelines. Kubernetes is a powerful container orchestration platform that automates the deployment, scaling, and management of containerized applications. In this article, we will discuss how to run Jenkins on Kubernetes.
+
+### Why Run Jenkins on Kubernetes?
+
+Running Jenkins on Kubernetes provides several benefits, including:
+
+- Scalability: Kubernetes can automatically scale Jenkins instances based on workload demands.
+- High availability: Kubernetes can ensure that Jenkins is always available by automatically restarting failed instances.
+- Portability: Jenkins can be easily moved between Kubernetes clusters, making it easier to manage and migrate.
+
+### Prerequisites
+
+Before we can run Jenkins on Kubernetes, we need to have the following:
+
+- A Kubernetes cluster: You can create a Kubernetes cluster using a cloud provider like AWS or GCP, or you can set up a local cluster using tools like Minikube or Kind.
+- Helm: Helm is a package manager for Kubernetes that makes it easy to install, upgrade, and manage applications. You can install Helm by following the instructions on the Helm website.
+
+### Installing Jenkins on Kubernetes
+
+To install Jenkins on Kubernetes, we will use the Jenkins Helm chart. The Helm chart is a package that contains all the necessary Kubernetes manifests, configuration files, and dependencies needed to run Jenkins on Kubernetes.
+
+To install the Jenkins Helm chart, follow these steps:
+
+1. Add the Jenkins Helm repository to Helm:
+
+   


### PR DESCRIPTION
Generated code from OpenAI prompt:

write an article about running kubernetes based jenkins servers

Generated code:

```running-kubernetes-based-jenkins-servers.md

Jenkins is a popular open-source automation server used for continuous integration and continuous delivery (CI/CD) pipelines. Kubernetes is a powerful container orchestration platform that automates the deployment, scaling, and management of containerized applications. In this article, we will discuss how to run Jenkins on Kubernetes.

### Why Run Jenkins on Kubernetes?

Running Jenkins on Kubernetes provides several benefits, including:

- Scalability: Kubernetes can automatically scale Jenkins instances based on workload demands.
- High availability: Kubernetes can ensure that Jenkins is always available by automatically restarting failed instances.
- Portability: Jenkins can be easily moved between Kubernetes clusters, making it easier to manage and migrate.

### Prerequisites

Before we can run Jenkins on Kubernetes, we need to have the following:

- A Kubernetes cluster: You can create a Kubernetes cluster using a cloud provider like AWS or GCP, or you can set up a local cluster using tools like Minikube or Kind.
- Helm: Helm is a package manager for Kubernetes that makes it easy to install, upgrade, and manage applications. You can install Helm by following the instructions on the Helm website.

### Installing Jenkins on Kubernetes

To install Jenkins on Kubernetes, we will use the Jenkins Helm chart. The Helm chart is a package that contains all the necessary Kubernetes manifests, configuration files, and dependencies needed to run Jenkins on Kubernetes.

To install the Jenkins Helm chart, follow these steps:

1. Add the Jenkins Helm repository to Helm:

   ```