### PR TITLE
Make frankc.net crawlable: fix robots.txt, CNAME, SEO meta, JSON-LD, llms.txt

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,1 @@
 frankc.net
-www.frankc.net

--- a/_config.yml
+++ b/_config.yml
@@ -147,7 +147,7 @@ title-separator: "-"
 # --- Don't need to touch anything below here (but you can if you want) --- #
 
 # Output options (more information on Jekyll's site)
-timezone: "America/New York"
+timezone: "America/New_York"
 markdown: kramdown
 highlighter: rouge
 permalink: /:year-:month-:day-:title/

--- a/_config.yml
+++ b/_config.yml
@@ -180,6 +180,8 @@ link-tags: true
 # Exclude these files from production site
 exclude:
   - CHANGELOG.md
+  - CHANGELOG_FXCHEN.md
+  - CLAUDE.md
   - CNAME
   - Dockerfile
   - Gemfile
@@ -263,6 +265,7 @@ prose:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 
 # - jekyll-gist

--- a/_config.yml
+++ b/_config.yml
@@ -109,7 +109,9 @@ url-pretty: "frankc.net"  # eg. "deanattali.com/beautiful-jekyll"
 #gtag: ""
 
 # Fill in your Google Analytics ID to track your website using GA
-google_analytics: "UA-36961797-1"
+# (Universal Analytics shut down July 2023; set gtag above with a GA4
+# G-XXXXXXX measurement ID to re-enable analytics)
+#google_analytics: ""
 
 # Google Tag Manager ID
 #gtm: ""

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -139,6 +139,8 @@
   <meta name="twitter:image" content="{{ site.url }}{{ site.avatar }}" />
   {% endif %}
 
+  {% include structured-data.html %}
+
   {% if site.matomo %}
   {% include matomo.html %}
   {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,12 +3,16 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
 
-  <title>{% if page.use-site-title %}{{ site.title }} {{ site.title-separator }} {{ site.description }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <title>{% if page.use-site-title %}{{ site.title }} {{ site.title-separator }} {{ site.description }}{% elsif page.title %}{{ page.title }} {{ site.title-separator }} {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
 
   <meta name="author" content="{{ site.author.name }}" />
 
   {% if page.subtitle %}
   <meta name="description" content="{{ page.subtitle }}">
+  {% elsif page.id %}
+  <meta name="description" content="{{ page.content | strip_html | normalize_whitespace | truncate: 160 | xml_escape }}">
+  {% else %}
+  <meta name="description" content="{{ site.description }}">
   {% endif %}
 
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} {{ site.title-separator }} {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
@@ -75,7 +79,13 @@
   {% endif %}
 
 
+  {% if page.id %}
+  <meta property="og:type" content="article" />
+  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+  <meta property="article:author" content="{{ site.author.name }}" />
+  {% else %}
   <meta property="og:type" content="website" />
+  {% endif %}
 
   {% if page.id %}
   <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
@@ -95,9 +105,15 @@
 
 
   <!-- Twitter summary cards -->
+  {% if page.share-img or page.image %}
+  <meta name="twitter:card" content="summary_large_image" />
+  {% else %}
   <meta name="twitter:card" content="summary" />
+  {% endif %}
+  {% if site.author.twitter %}
   <meta name="twitter:site" content="@{{ site.author.twitter }}" />
   <meta name="twitter:creator" content="@{{ site.author.twitter }}" />
+  {% endif %}
 
   {% if page.meta-title %}
   <meta name="twitter:title" content="{{ page.meta-title }}" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,7 +49,11 @@
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
         <div class="{{ include.type }}-heading">
+          {% if page.bigimg %}
+          <div class="fallback-title">{% if page.title %}{{ page.title }}{% else %}<br/>{% endif %}</div>
+          {% else %}
           <h1>{% if page.title %}{{ page.title }}{% else %}<br/>{% endif %}</h1>
+          {% endif %}
 		  {% if page.subtitle %}
 		    {% if include.type == "page" %}
             <hr class="small">

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,0 +1,93 @@
+{% if page.url == "/" %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": "{{ site.url }}/#person",
+    "name": "Frank Chen",
+    "url": "{{ site.url }}/",
+    "image": "{{ site.url }}{{ site.avatar }}",
+    "jobTitle": "Co-founder & CTO",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "Balto Energy"
+    },
+    "description": "Frank Chen is co-founder and CTO of Balto Energy, a climate tech startup using AI to transform home energy. Before Balto, he led developer infrastructure special projects at Slack, built data platforms at Palantir, and launched AWS WorkDocs at Amazon.",
+    "alumniOf": [
+      {
+        "@type": "CollegeOrUniversity",
+        "name": "Stanford University"
+      },
+      {
+        "@type": "CollegeOrUniversity",
+        "name": "University of California, Los Angeles"
+      }
+    ],
+    "email": "mailto:hello@frankc.net",
+    "sameAs": [
+      "https://github.com/fxchen",
+      "https://www.linkedin.com/in/fxchen",
+      "https://www.instagram.com/fxchen"
+    ]
+  }
+  </script>
+{% endif %}
+{% if page.id %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "{{ site.url }}{{ page.url }}"
+    },
+    "headline": {{ page.title | jsonify }},
+    "description": {% if page.subtitle %}{{ page.subtitle | jsonify }}{% else %}{{ page.content | strip_html | normalize_whitespace | truncate: 160 | jsonify }}{% endif %},
+    {% if page.share-img %}
+    "image": {{ page.share-img | jsonify }},
+    {% elsif page.image %}
+    "image": {{ page.image | absolute_url | jsonify }},
+    {% endif %}
+    "datePublished": "{{ page.date | date_to_xmlschema }}",
+    "dateModified": "{% if page.modified-date %}{{ page.modified-date | date_to_xmlschema }}{% else %}{{ page.date | date_to_xmlschema }}{% endif %}",
+    "author": {
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "Frank Chen",
+      "url": "{{ site.url }}/"
+    },
+    "publisher": {
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "Frank Chen",
+      "url": "{{ site.url }}/"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "{{ site.url }}/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Writing",
+        "item": "{{ site.url }}/writing/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": {{ page.title | jsonify }},
+        "item": "{{ site.url }}{{ page.url }}"
+      }
+    ]
+  }
+  </script>
+{% endif %}

--- a/_posts/2014-08-09-how-to-design-for-habits.md
+++ b/_posts/2014-08-09-how-to-design-for-habits.md
@@ -2,7 +2,7 @@
 layout: post
 title: How to Design for Habit
 subtitle: The Secret to Making Great Products
-permalink: behavioral-antipatterns-product-design
+permalink: how-to-design-for-habits
 image: https://raw.githubusercontent.com/fxchen/frankc/master/2014%20July/spiral.jpg
 modified-date: Sep 16, 2018
 ---

--- a/_posts/2014-11-02-behavioral-antipatterns-product-design.md
+++ b/_posts/2014-11-02-behavioral-antipatterns-product-design.md
@@ -2,8 +2,9 @@
 layout: post
 title: “Why Your App Got Deleted…” Behavioral Antipatterns for Product Design
 subtitle: Many apps get deleted. How can you make sure your app doesn’t get deleted? This essay shares patterns and antipatterns for product design
-<!-- permalink: behavioral-antipatterns-product-design.md -->
-<!-- image: /img/posts/meditation-goenka-thumb.jpg -->
+permalink: behavioral-antipatterns-product-design
+redirect_from:
+  - /2014-11-02-behavioral-antipatterns-product-design/
 modified-date: Sep 16, 2018
 ---
 Notice how many the apps on your phone don’t get used.

--- a/css/main-extend.css
+++ b/css/main-extend.css
@@ -35,6 +35,19 @@ body, a {
   text-shadow: 1px 1px 8px rgb(240,240,240);
 }
 
+/* Small-screen fallback header on pages with a big image: styled like the
+   h1 it replaces, but a div so the page keeps a single semantic H1 */
+.intro-header .page-heading .fallback-title {
+  margin-top: 0;
+  font-size: 50px;
+  font-weight: 400;
+}
+.intro-header .post-heading .fallback-title {
+  margin-top: 0;
+  font-size: 35px;
+  font-weight: 400;
+}
+
 /* ----- Search Bar -------*/
 .nav-search-link .nav-search-icon {
   display: none;

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# Frank Chen — frankc.net
+
+> Frank Chen is co-founder and CTO of Balto Energy, a climate tech startup using AI to transform home energy. Before Balto, he led developer infrastructure special projects at Slack, built data platforms at Palantir for healthcare, energy, and finance customers, and launched AWS WorkDocs at Amazon. He holds an M.S. in Computer Science (HCI) from Stanford, where he worked in BJ Fogg's Persuasive Technology Lab, and a B.S. in Computer Science from UCLA.
+
+He writes about deploying real AI in the messy physical world: agents, knowledge graphs, and workflows that survive permits, people, bills, and operations with consequences — what actually ships vs. what demos well.
+
+## Start here
+
+- [About Frank Chen](https://frankc.net/): bio (short and full), background, and what he works on
+- [Writing](https://frankc.net/writing/): all essays, newest first
+- [Media](https://frankc.net/media): talks, podcasts, book chapters, and open-source projects
+
+## Selected essays
+
+- [What It Feels Like to Rebuild a Company Around a Graph](https://frankc.net/rebuilding-our-company): going forward-deployed in Palantir Foundry and rebuilding a company around an ontology
+- [The Handoff Was the Bug. Vertical AI Is the Rewrite.](https://frankc.net/vertical-ai-rewrite): quality used to come from approvals; now it comes from correction
+- [The Operations CEO Doesn't Wait for the Dashboard](https://frankc.net/forward-deployed-engineer-executive): what happens when the forward-deployed engineer is the CEO himself
+- [The Moat Is What You Capture](https://frankc.net/capture-before-reasoning): reasoning gets cheaper; capture compounds
+- [We Built the Enterprise Brain. It Was the Easy Part.](https://frankc.net/enterprise-brain-router): fat skills, one per work function
+- [Our AI Onboards New Hires Better Than We Do](https://frankc.net/ai-onboarding): using Claude Code to personalize onboarding from a living knowledge base
+- [We Put Our Entire Company's Brain in a Git Repo](https://frankc.net/company-vault): ARKS, AI agents, and company knowledge in plain markdown
+- [AI Has Entered the Chat](https://frankc.net/ai-entered-chat): humans, AI, and the art of collaboration (CraftConf 2023)
+- [Design your Personal Operating System — Habits](https://frankc.net/personal-operating-system): habits as the operating system you live your life through
+
+## Meta
+
+- [Sitemap](https://frankc.net/sitemap.xml)
+- [RSS feed](https://frankc.net/feed.xml)

--- a/pages/log.md
+++ b/pages/log.md
@@ -7,7 +7,7 @@ subtitle: A very incomplete list of projects, references, etc
 
 # Media
 
-A very incomplete list of projects, references, etc. Roughly ordered chronologically.
+Talks, podcasts, book chapters, and open-source projects by Frank Chen, co-founder and CTO of Balto Energy. A very incomplete list of projects, references, etc. Roughly ordered chronologically.
 
 ## 2023
 

--- a/pages/log.md
+++ b/pages/log.md
@@ -11,7 +11,7 @@ A very incomplete list of projects, references, etc. Roughly ordered chronologic
 
 ## 2023
 
-AI Powered Development Workflows: Sharing initial experiments with generative models and their challenges in developer workflows [[Developer Experience Summit](http://localhost:4000/writing/)]. I delved into the integration of generative artificial intelligence (AI) models into the developer workflow, exploring initial experiments with AI-powered code review in open source repositories at Slack.
+AI Powered Development Workflows: Sharing initial experiments with generative models and their challenges in developer workflows [[Developer Experience Summit](/ai-dev)]. I delved into the integration of generative artificial intelligence (AI) models into the developer workflow, exploring initial experiments with AI-powered code review in open source repositories at Slack.
 
 
 AI Has Entered the Chat: Humans, AI, and the Art of Collaboration [[craftconf talk](https://craft-conf.com/2023/talk/frank-chens-talk)] [[talk references](https://frankc.net/ai-entered-chat)]. I explored the potential of integrating large language models and generative artificial intelligence (AI) agents into our work processes.

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,42 @@
 User-agent: *
-Disallow: /
+Allow: /
+
+# Search crawlers
+User-agent: Googlebot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+# AI assistant crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+Sitemap: https://frankc.net/sitemap.xml

--- a/writing/index.html
+++ b/writing/index.html
@@ -22,7 +22,7 @@ show-avatar : true
       {% if post.image %}
       <div class="post-image">
         <a href="{{ post.url | prepend: site.baseurl }}">
-          <img src="{{ post.image }}" style="{% if post.image-height %} height: {{post.image-height}}{% endif %}; {% if post.image-width %} width: {{post.image-width}}{% endif %}">
+          <img src="{{ post.image }}" alt="{{ post.title }}" style="{% if post.image-height %} height: {{post.image-height}}{% endif %}; {% if post.image-width %} width: {{post.image-width}}{% endif %}">
         </a>
       </div>
       {% endif %}

--- a/writing/index.html
+++ b/writing/index.html
@@ -5,6 +5,8 @@ title: Writing
 show-avatar : true
 ---
 
+<p>Essays by Frank Chen, co-founder and CTO of Balto Energy, on AI agents, knowledge systems, developer infrastructure, and behavior design — what actually ships vs. what demos well.</p>
+
 <div class="posts-list">
   {% for post in paginator.posts %}
   <article class="post-preview">


### PR DESCRIPTION
Fixes site crawlability and adds SEO/GEO improvements across 5 commits:

1. **robots.txt + CNAME** — robots.txt was `Disallow: /` (blocking all crawlers including Google and AI bots); now allows all, explicitly allows GPTBot/ClaudeBot/OAI-SearchBot/PerplexityBot/Google-Extended, and links the sitemap. CNAME reduced to single line `frankc.net` (two-line CNAME breaks GitHub Pages custom-domain binding).
2. **Permalink collision** — `/behavioral-antipatterns-product-design` now serves the actual Behavioral Antipatterns post; "How to Design for Habit" moved to `/how-to-design-for-habits`; old dated URL 301s. Excluded CLAUDE.md and internal files from the published site.
3. **On-page SEO** — meta description fallback, `og:type article` + published time on posts, removed broken empty Twitter handle, single H1, fixed localhost link on /media.
4. **GEO** — Person JSON-LD on home, BlogPosting + BreadcrumbList on posts, `/llms.txt` routing index.
5. **Analytics** — removed dead Universal Analytics tag (UA shut down July 2023; set `gtag` with a GA4 ID to re-enable).

After merge, Cloudflare dashboard still needs: SSL **Full (strict)**, Bot Fight Mode / AI-bot blocking **off**, Always Use HTTPS on.

https://claude.ai/code/session_014waRHrknA5nc9qrGUnTASz

---
_Generated by [Claude Code](https://claude.ai/code/session_014waRHrknA5nc9qrGUnTASz)_