### PR TITLE
Add IndexNow key file (sitemap submission setup, part 1 of 2)

### DIFF
--- a/97fbabffb4a4e8d86a4bf7cd1ff70ac4.txt
+++ b/97fbabffb4a4e8d86a4bf7cd1ff70ac4.txt
@@ -1,0 +1,1 @@
+97fbabffb4a4e8d86a4bf7cd1ff70ac4


### PR DESCRIPTION
Adds the public IndexNow domain-verification key file, served at `https://frankc.net/97fbabffb4a4e8d86a4bf7cd1ff70ac4.txt`.

Part 2 (the `submit-sitemap.yml` GitHub Actions workflow) can't be pushed by this integration — it lacks the `workflows` permission — so Frank adds it manually via the GitHub UI. The workflow submits all sitemap URLs to IndexNow (Bing/Yandex/Seznam/Naver) on content pushes to master, with a monthly safety-net cron and optional Google Search Console API submission once a `GSC_SA_KEY` secret exists. Google's anonymous sitemap ping endpoint was removed in 2024; robots.txt + lastmod remains Google's discovery path meanwhile.

https://claude.ai/code/session_014waRHrknA5nc9qrGUnTASz

---
_Generated by [Claude Code](https://claude.ai/code/session_014waRHrknA5nc9qrGUnTASz)_